### PR TITLE
Добавление отсрочки для запроса поиска книги

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -65,11 +65,16 @@ if (searchInput) {
         searchInput.focus();
     });
 
+    
+    let searchBookDebounceTimeout = null;
+    
     searchInput.addEventListener('input', () => {
         bookTitle = searchInput.value;
         if (bookTitle.length !== 1) {
             event.preventDefault();
-            searchBook(bookTitle);
+            
+            clearTimeout(searchBookDebounceTimeout);
+            searchBookDebounceTimeout = setTimeout(() => searchBook(bookTitle), 300);
         }
     });
 }


### PR DESCRIPTION
Привет.

Проходил мимо, увидел проект, он мне приглянулся, и я решил поправить в нём небольшую багу.

Сейчас во время ввода символов, на каждое нажатие клавиши уходит запрос на сервер. Это приводит к гонкам запросов и к неакдеватной выдаче в тех случаях, когда пользователь быстро вводит текст. 

Вот, как работает сейчас:

![before](https://user-images.githubusercontent.com/6537798/85957051-a8686880-b992-11ea-9d31-09c0135be8f5.gif)

(Обратите внимание на вереницу запросов, и на то, как они друг за другом резолвятся, по пути выдавая какой-то промежуточный, нерелевантный результат.)

Вот, как будет работать после PR:

![after](https://user-images.githubusercontent.com/6537798/85957075-e36a9c00-b992-11ea-80a2-c03de4259d0e.gif)

Запрос уходит через 300 мс после последнего ввода, потому лишних запросов не появляется.

Не знаю, насколько это важно и нужно, потому, если не нужно, то смело отклоняйте пулреквест :-)

(Редактировал файл на Гитхабе, потому может что-то не так изменилось, как должно было бы. Линтеры там, сборщики, то-сё.)